### PR TITLE
Adding babel-plugin-transform-react-jsx to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-es2015": "^6.9.0",
     "hyperscript": "^1.4.7",
     "webpack": "^1.13.1",


### PR DESCRIPTION
`package.json` was missing this dependency before, so `npm install` and `npm run build` would not work out of the box.